### PR TITLE
Version 22.12.3.1: remove condition to hide lat/long inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MpiIsoApp
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 22.12.3
+Version: 22.12.3.1
 Author: INWT Statistics GmbH
 Maintainer: INWT <marcus.gross@inwt-statistics.de>
 Description: Shiny App contains: a data explorer tab, an interactive map and a static map, which should present model results.
@@ -48,4 +48,4 @@ Suggests:
   lintr (>= 1.0.2),
   testthat (>= 2.0.0),
   ReSources (>= 0.7.9)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
 # MpiIsoApp development version
 
-## MpiIsoApp 22.12.3.1
+## Version 22.12.3.1
 
 ### Bug Fixes
-- inputs for Latitude and Longitude were falsely hidden for time plots in TimeR and KernelTimeR (#94)
+- inputs for latitude and longitude were falsely hidden for time plots in TimeR and KernelTimeR (#94)
 
 ## MpiIsoApp 22.12.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # MpiIsoApp development version
 
+## MpiIsoApp 22.12.3.1
+
+### Bug Fixes
+- inputs for Latitude and Longitude were falsely hidden for time plots in TimeR and KernelTimeR (#94)
+
 ## MpiIsoApp 22.12.3
 
 ### Updates

--- a/R/02-modules-modelResultHelpers.R
+++ b/R/02-modules-modelResultHelpers.R
@@ -31,7 +31,8 @@ centerEstimateUI <- function(id, title = "") {
       width = "100%"
     ),
     conditionalPanel(
-      condition = "input.centerY != null && input.centerY != '' && input.centerX != null && input.centerX != ''",
+      condition =
+        "input.centerY != null && input.centerY != '' && input.centerX != null && input.centerX != '' && output.isCenterEstimateMap == true",
       numericInput(
         inputId = ns("decimalPlace"),
         label = "Decimal places for Mean/Error at the Center point",
@@ -77,7 +78,14 @@ centerEstimateServer <-
                    # "Speed" (a map but no meanCenter, sdCenter in the output available),
                    # "Minima/Maxima"
 
+                   output$isCenterEstimateMap <- reactive({
+                     mapType() %in% centerEstimateMaps
+                   })
+                   outputOptions(output, "isCenterEstimateMap", suspendWhenHidden = FALSE)
+
                    observeEvent(list(meanCenter(), sdCenter(), input$decimalPlace), {
+                     # meanCenter(), sdCenter() depend on input$centerX, input$centerY
+                     # -> do not extra observe on input$centerX, input$centerY
                      if (is.na(input$centerY) |
                          is.na(input$centerX) |
                          is.na(input$Radius) |

--- a/R/03-modelResults3D.R
+++ b/R/03-modelResults3D.R
@@ -466,14 +466,7 @@ modelResults3DUI <- function(id, title = ""){
                       label = "Colour of font",
                       value = "#2C2161")
                       , ns = ns),
-        conditionalPanel(
-          condition = "input.mapType == 'Map'",
-          ns = ns,
-          centerEstimateUI(ns("centerEstimateParams"))
-        ),
-        sliderInput(inputId = ns("Radius"),
-                    label = "Radius (km)",
-                    min = 10, max = 300, value = 100, step = 10, width = "100%"),
+        centerEstimateUI(ns("centerEstimateParams")),
         sliderInput(inputId = ns("AxisSize"),
                     label = "Axis title font size",
                     min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),

--- a/R/03-modelResults3DKernel.R
+++ b/R/03-modelResults3DKernel.R
@@ -404,11 +404,7 @@ modelResults3DKernelUI <- function(id, title = ""){
             sliderInput(inputId = ns("ncol"),
                         label = "Approximate number of colour levels",
                         min = 4, max = 50, value = 50, step = 2, width = "100%"),
-            conditionalPanel(
-              condition = "input.mapType == 'Map'",
-              ns = ns,
-              centerEstimateUI(ns("centerEstimateParams"))
-            ),
+            centerEstimateUI(ns("centerEstimateParams")),
             tags$hr()
             ),
           checkboxInput(inputId = ns("smoothCols"),

--- a/R/03-modelResultsSpread.R
+++ b/R/03-modelResultsSpread.R
@@ -401,11 +401,7 @@ modelResultsSpreadUI <- function(id, title = ""){
             colourInput(inputId = ns("fontCol"),
                         label = "Colour of font",
                         value = "#2C2161"), ns = ns),
-          conditionalPanel(
-            condition = "input.mapType == 'Spread'",
-            ns = ns,
-            centerEstimateUI(ns("centerEstimateParams"))
-          ),
+          centerEstimateUI(ns("centerEstimateParams")),
           sliderInput(inputId = ns("AxisSize"),
                       label = "Axis title font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),


### PR DESCRIPTION
## Version 22.12.3.1

### Bug Fixes
- inputs for latitude and longitude were falsely hidden for time plots in TimeR and KernelTimeR (#94)