### PR TITLE
Version 23.05.2: Feat/133 borders and names on maps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MpiIsoApp
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 23.05.1
+Version: 23.05.2
 Author: INWT Statistics GmbH
 Maintainer: INWT <marcus.gross@inwt-statistics.de>
 Description: Shiny App contains: a data explorer tab, an interactive map and a static map, which should present model results.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ### New Features
 - _Interactive Map_: 
-  - map types are grouped by having borders or names
+  - map types are grouped by having borders or names (#133)
   - option to add more maps from different providers: https://leaflet-extras.github.io/leaflet-providers/preview/
 
 ## Version 23.05.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # MpiIsoApp development version
 
+## Version 23.05.2
+
+### New Features
+- _Interactive Map_: 
+  - map types are grouped by having borders or names
+  - option to add more maps from different providers: https://leaflet-extras.github.io/leaflet-providers/preview/
+
 ## Version 23.05.1
 
 ### Updates

--- a/R/02-leafletSettings.R
+++ b/R/02-leafletSettings.R
@@ -7,25 +7,40 @@ leafletSettingsUI <- function(id, title = "") {
 
   tagList(
     tags$h2(title),
-    selectInput(
+    selectizeInput(
       ns("LeafletType"),
-      "Map type",
-      choices = c(
+      label = "Map type",
+      choices = list(
+        `borders & names`= c(
         "CartoDB Positron" = "CartoDB.Positron",
-        "CartoDB Positron No Labels" = "CartoDB.PositronNoLabels",
         "OpenStreetMap Mapnik" = "OpenStreetMap.Mapnik",
         "OpenStreetMap DE" = "OpenStreetMap.DE",
         "OpenTopoMap" = "OpenTopoMap",
         "Stamen TonerLite" = "Stamen.TonerLite",
         "Esri" = "Esri",
         "Esri WorldTopoMap" = "Esri.WorldTopoMap",
+        "Esri OceanBasemap" = "Esri.OceanBasemap"
+      ),
+      `only borders`= c(
+        "CartoDB Positron No Labels" = "CartoDB.PositronNoLabels"
+      ),
+      `plain maps`= c(
         "Esri WorldImagery" = "Esri.WorldImagery",
         "Esri WorldTerrain" = "Esri.WorldTerrain",
         "Esri WorldShadedRelief" = "Esri.WorldShadedRelief",
-        "Esri WorldPhysical" = "Esri.WorldPhysical",
-        "Esri OceanBasemap" = "Esri.OceanBasemap"
+        "Esri WorldPhysical" = "Esri.WorldPhysical"
+      ),
+      `custom maps` = c(
+        "Stamen.Watercolor" = "Stamen.Watercolor"
       )
     ),
+    options = list(create = TRUE)
+    ),
+    helpText(HTML(paste0("Find more maps at: <br>",
+                         tags$a(href = "https://leaflet-extras.github.io/leaflet-providers/preview/",
+                                "https://leaflet-extras.github.io/leaflet-providers/preview/",
+                                target = "_blank"),
+                         "<br> Type the name and click 'Add...'."))),
     fluidRow(column(6, checkboxInput(
       ns("includeNorthArrow"), "North Arrow"
     )),

--- a/R/02-leafletSettings.R
+++ b/R/02-leafletSettings.R
@@ -36,11 +36,24 @@ leafletSettingsUI <- function(id, title = "") {
     ),
     options = list(create = TRUE)
     ),
-    helpText(HTML(paste0("Find more maps at: <br>",
+    helpText(HTML(paste0("Find more maps: <br>",
                          tags$a(href = "https://leaflet-extras.github.io/leaflet-providers/preview/",
                                 "https://leaflet-extras.github.io/leaflet-providers/preview/",
                                 target = "_blank"),
-                         "<br> Type the name and click 'Add...'."))),
+                         " ",
+                         tags$i(
+                           class = "glyphicon glyphicon-info-sign",
+                           style = "color:#0072B2;",
+                           title = paste(
+                             "How to apply a new map:",
+                             " 1. Delete the input of the field 'Map type',",
+                             " 2. copy the name of the desired map into that field, and",
+                             " 3. click 'Add...'. ",
+                             "Some maps are not supported. Please try, e.g. 'OpenStreetMap',",
+                             " 'Stamen', 'Esri', 'CartoDB', 'NASAGIBS', 'GeoportailFrance'.",
+                             sep = "\n"
+                           ))
+    ))),
     fluidRow(column(6, checkboxInput(
       ns("includeNorthArrow"), "North Arrow"
     )),


### PR DESCRIPTION
## Version 23.05.2

### New Features
- _Interactive Map_: 
  - map types are grouped by having borders or names (#133)
  - option to add more maps from different providers: https://leaflet-extras.github.io/leaflet-providers/preview/ (1)

![image](https://user-images.githubusercontent.com/16759098/236189253-b61080f2-5afc-4302-ab23-7937420c1500.png)
