### PR TITLE
more logging of object size and fix in KernelTimeR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DSSM
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 25.12.0
+Version: 26.01.0
 Authors@R: c(
             person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("cre", "aut")),
             person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DSSM 26.01.0
+
+## Updates
+- Added logging of object sizes also to the modelling tabs _KernelR, KernelTimeR, SpreadR AssignR_ (#206)
+
 # DSSM 25.12.0
 
 ## Bug Fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 - Added logging of object sizes also to the modelling tabs _KernelR, KernelTimeR, SpreadR AssignR_ (#206)
 
 ## Bug Fixes
-- Fixed issue with hidden UI for setting the center estimates in _KernelTimeR_ for _Time course_ plots (#292)
+- Fixed hidden UI for setting the center estimates in _KernelTimeR_ time course plots (#292)
+- Fixed decimal-place settings for axis labels: x and y axes now have separate inputs, with an improved default for the y axis (1 decimal place) to prevent rounding issues (#292)
 
 # DSSM 25.12.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 ## Updates
 - Added logging of object sizes also to the modelling tabs _KernelR, KernelTimeR, SpreadR AssignR_ (#206)
 
+## Bug Fixes
+- Fixed issue with hidden UI for setting the center estimates in _KernelTimeR_ for _Time course_ plots (#292)
+
 # DSSM 25.12.0
 
 ## Bug Fixes

--- a/R/00-logging.R
+++ b/R/00-logging.R
@@ -57,9 +57,14 @@ log_memory_usage <- function() {
     logWarn("Critical memory %s %s.", current_mem_msg, mem_warning)
 }
 
-log_object_size <- function(object, object_name = deparse(substitute(object))) {
+log_object_size <- function(object, object_name = deparse(substitute(object)), log_memory = TRUE) {
   # Only compute object size if debug logging is enabled
   if (futile.logger::flog.threshold() <= futile.logger::DEBUG) {
-    logDebug(sprintf("Size of %s: %s", object_name, pryr::object_size(object) |> format(units = "auto")))
+    logDebug(sprintf(
+      "Size of %s: %s", object_name, pryr::object_size(object) |>
+        format(units = "auto")
+    ))
+    # if logging object size then also log memory usage
+    if (log_memory) log_memory_usage()
   }
 }

--- a/R/00-logging.R
+++ b/R/00-logging.R
@@ -59,7 +59,7 @@ log_memory_usage <- function() {
 
 log_object_size <- function(object, object_name = deparse(substitute(object)), log_memory = TRUE) {
   # Only compute object size if debug logging is enabled
-  if (futile.logger::flog.threshold() <= futile.logger::DEBUG) {
+  if (identical(futile.logger::flog.threshold(), "DEBUG")) {
     logDebug(sprintf(
       "Size of %s: %s", object_name, pryr::object_size(object) |>
         format(units = "auto")

--- a/R/01-estimateAssignR.R
+++ b/R/01-estimateAssignR.R
@@ -188,6 +188,7 @@ fitModelAssignR <- function(XNUM, XCAT, y, yUnc = NULL, xUncNUM = NULL, xUncCAT 
 
 
   for ( k in 1:5) {
+    log_memory_usage()
     j <- seq(1, iter, iter / 5)[k]
     showMessage(
       MCMC_AssignR,
@@ -204,6 +205,7 @@ fitModelAssignR <- function(XNUM, XCAT, y, yUnc = NULL, xUncNUM = NULL, xUncCAT 
   every <- thinning  #nur die x-te MCMC-Iteration soll genutzt werden
   #Vektor der tatsaechlich benutzten Beobachtungen
   usedsamples <- unlist(sapply(1:nChains, function(k) seq(from = burnin[k], to = iter / nChains * k, by = every)))
+  log_memory_usage()
   return(list(beta = betamc[usedsamples, , drop = F],
               mRe = mRe, sRe = sRe,
               nChains = nChains))

--- a/R/01-estimateMap.R
+++ b/R/01-estimateMap.R
@@ -1270,7 +1270,6 @@ modelLocalAvg <- function(data, K, iter, burnin, independent, smoothConst,
         start = j, iter = j + iter / 10 - 1
       )
   }
-  log_memory_usage()
   # burnin <- round(burnInProp * iter)
   # every <- thinning  #nur die x-te MCMC-Iteration soll genutzt werden
   # #Vektor der tatsaechlich benutzten Beobachtungen
@@ -1291,6 +1290,7 @@ modelLocalAvg <- function(data, K, iter, burnin, independent, smoothConst,
     pred_probs <- sapply(1:length(usedsamples), function(x) invLogit(XX %*% betamc[x, ]) * sRe + mRe)
     seTotal = range(sqrt(apply(pred_probs, 1, var) + pred_probs * (1-pred_probs)))
   }
+  log_memory_usage()
   return(list(beta = betamc, betaSigma = betamcSigma, sc = s, scV = sV, sigma = smc,
               tau = taumc, mRe = mRe, sRe = sRe,
               range = list(mean = range(rowMeans(sapply(1:length(usedsamples), function(x)
@@ -1674,6 +1674,7 @@ modelLocalTempAvg <- function(data, K, KT, iter, burnin, independent,
     pred_probs <- sapply(1:length(usedsamples), function(x) invLogit(XX2 %*% betamc[x, ]) * sRe + mRe)
     seTotal = range(sqrt(apply(pred_probs, 1, var) + pred_probs * (1-pred_probs)))
   }
+  log_memory_usage()
   return(list(beta = betamc, betaSigma = betamcSigma, sc = s, scV = sV, sigma = smc,
               tau = taumc, mRe = mRe, sRe = sRe,
               range = list(mean = range(rowMeans(sapply(1:length(usedsamples), function(x)
@@ -1956,7 +1957,7 @@ modelSpread <- function(data, K, iter, burnin, MinMax, smoothConst, penalty,
   every <- thinning  #nur die x-te MCMC-Iteration soll genutzt werden
   #Vektor der tatsaechlich benutzten Beobachtungen
   usedsamples <- seq(from = burnin, to = iter, by = every)
-
+  log_memory_usage()
   return(list(beta = betamc[usedsamples, ], sc = s, sigma = 0, tau = 0,
               pred = XX %*% colMeans(betamc[usedsamples, ]),
               mRe = mRe, sRe = sRe,

--- a/R/01-plotMap.R
+++ b/R/01-plotMap.R
@@ -2119,7 +2119,7 @@ plotTimeCourse <- function(model, IndSelect = NULL,
       min = min(time),
       max = max(time),
       nLabels = formatTimeCourse$nLabelsX,
-      decPlace = formatTimeCourse$axesDecPlace
+      decPlace = formatTimeCourse$decPlacesX
     )
 
     addFormattedAxis(
@@ -2127,7 +2127,7 @@ plotTimeCourse <- function(model, IndSelect = NULL,
       min = ylims[1],
       max = ylims[2],
       nLabels = formatTimeCourse$nLabelsY,
-      decPlace = formatTimeCourse$axesDecPlace
+      decPlace = formatTimeCourse$decPlacesY
     )
   }
 

--- a/R/02-batchModeling.R
+++ b/R/02-batchModeling.R
@@ -78,7 +78,9 @@ batchModeling <- function(input, output, session, data, plotFun, modelParams, ty
         res <- plotFun()(Model())
         values$updated <- Sys.time()
         values$predictions <- res$XPred
+        log_object_size(values$predictions)
         values$plot <- recordPlot()
+        log_object_size(values$plot)
     })
 
 

--- a/R/02-modelMap_UIHelpers.R
+++ b/R/02-modelMap_UIHelpers.R
@@ -12,6 +12,7 @@ centerEstimateUI <- function(id, title = "") {
   ns <- NS(id)
 
   tagList(
+    tags$br(),
     tags$strong("Center estimates:"),
     numericInput(
       inputId = ns("centerY"),
@@ -53,7 +54,8 @@ centerEstimateUI <- function(id, title = "") {
         step = 10,
         width = "100%"
       )
-    )
+    ),
+    tags$br()
   )
 }
 

--- a/R/02-modelMap_UIHelpers.R
+++ b/R/02-modelMap_UIHelpers.R
@@ -282,38 +282,47 @@ formatTimeCourseUI <- function(id, title = "") {
   ns <- NS(id)
 
   tagList(
-    numericInput(
-      inputId = ns("axesDecPlace"),
-      label = "Decimal places for axes",
-      min = 0,
-      max = 10,
-      value = 0,
-      step = 1,
-      width = "100%"
-    ),
-    fluidRow(
-      column(
-        width = 6,
-        numericInput(
-          inputId = ns("nLabelsX"),
-          label = "N labels of x axis",
-          min = 0,
-          max = 20,
-          value = 7,
-          step = 1,
-          width = "100%"
+    tags$br(),
+    tags$fieldset(
+      tags$strong("Decimal places"),
+      fluidRow(
+        column(
+          6,
+          numericInput(
+            ns("decPlacesX"),
+            label = "X axis",
+            min = 0, max = 10, value = 0, step = 1
+          )
+        ),
+        column(
+          6,
+          numericInput(
+            ns("decPlacesY"),
+            label = "Y axis",
+            min = 0, max = 10, value = 1, step = 1
+          )
         )
-      ),
-      column(
-        width = 6,
-        numericInput(
-          inputId = ns("nLabelsY"),
-          label = "N labels of y axis",
-          min = 0,
-          max = 20,
-          value = 7,
-          step = 1,
-          width = "100%"
+      )
+    ),
+    tags$br(),
+    tags$fieldset(
+      tags$strong("Number of labels"),
+      fluidRow(
+        column(
+          6,
+          numericInput(
+            ns("nLabelsX"),
+            label = "X axis",
+            min = 0, max = 20, value = 7, step = 1
+          )
+        ),
+        column(
+          6,
+          numericInput(
+            ns("nLabelsY"),
+            label = "Y axis",
+            min = 0, max = 20, value = 7, step = 1
+          )
         )
       )
     )
@@ -332,7 +341,8 @@ formatTimeCourseServer <-
                  function(input, output, session) {
                    reactive(
                      list(
-                       axesDecPlace = input$axesDecPlace,
+                       decPlacesX = input$decPlacesX,
+                       decPlacesY = input$decPlacesY,
                        nLabelsX = input$nLabelsX,
                        nLabelsY = input$nLabelsY
                      )
@@ -636,7 +646,7 @@ zScaleUI <-
           inputId = ns("min"),
           label = "Min range",
           value = 0
-        ),
+        )
       ),
       conditionalPanel(
         ns = ns,
@@ -650,7 +660,8 @@ zScaleUI <-
             "0-100" = "0-100"
           )
         )
-      )
+      ),
+      tags$br()
     )
   }
 
@@ -693,9 +704,10 @@ zScaleServer <- function(id,
                  output$titleScaleInput <- renderText({
                    switch(
                      mapType(),
-                     "Time course" = "Range of y axis:",
-                     "Minima/Maxima" = "Range of y axis:",
-                     "Range of estimates:"
+                     "Time course" = "Range of y axis",
+                     "Minima/Maxima" = "Range of y axis",
+                     "Time intervals by temporal group or cluster" = "Range of y axis",
+                     "Range of estimates"
                    )
                  })
 

--- a/R/03-mapDiff.R
+++ b/R/03-mapDiff.R
@@ -1090,6 +1090,7 @@ mapDiff <- function(input, output, session, savedMaps, fruitsData){
       res <- plotFun()()
     }, min = 0, max = 1, value = 0.8, message = "Plotting map ...")
     values$predictions <- res$XPred
+    log_object_size(values$predictions)
     values$plot <- recordPlot()
   })
 

--- a/R/03-mapDiff.R
+++ b/R/03-mapDiff.R
@@ -1092,6 +1092,7 @@ mapDiff <- function(input, output, session, savedMaps, fruitsData){
     values$predictions <- res$XPred
     log_object_size(values$predictions)
     values$plot <- recordPlot()
+    log_object_size(values$plot)
   })
 
   output$centerEstimate <- renderUI({

--- a/R/03-mapSim.R
+++ b/R/03-mapSim.R
@@ -654,6 +654,7 @@ mapSim <- function(input, output, session, savedMaps, fruitsData){
     values$predictions <- res$XPred
     log_object_size(values$predictions)
     values$plot <- recordPlot()
+    log_object_size(values$plot)
     }
   })
 

--- a/R/03-mapSim.R
+++ b/R/03-mapSim.R
@@ -652,6 +652,7 @@ mapSim <- function(input, output, session, savedMaps, fruitsData){
       alert(res)
     } else {
     values$predictions <- res$XPred
+    log_object_size(values$predictions)
     values$plot <- recordPlot()
     }
   })

--- a/R/03-modelResults2D.R
+++ b/R/03-modelResults2D.R
@@ -876,6 +876,7 @@ modelResults2D <- function(input, output, session, isoData, savedMaps, fruitsDat
     values$predictions <- res$XPred
     log_object_size(values$predictions)
     values$plot <- recordPlot()
+    log_object_size(values$plot)
   })
 
   output$centerEstimate <- renderUI({

--- a/R/03-modelResults2D.R
+++ b/R/03-modelResults2D.R
@@ -959,6 +959,7 @@ modelResults2D <- function(input, output, session, isoData, savedMaps, fruitsDat
       allData$Outlier[which(rownames(allData) %in% outlier)] <- "model outlier"
       allData$Outlier[which(rownames(allData) %in% outlierDR)] <- "data outlier"
       log_object_size(allData)
+      log_memory_usage()
       return(allData)
     }
   })

--- a/R/03-modelResults2D.R
+++ b/R/03-modelResults2D.R
@@ -454,6 +454,7 @@ modelResults2D <- function(input, output, session, isoData, savedMaps, fruitsDat
     # reset model
     Model(NULL)
     data(activeData)
+    log_object_size(data())
   })
 
   coordType <- reactive({
@@ -504,6 +505,7 @@ modelResults2D <- function(input, output, session, isoData, savedMaps, fruitsDat
     Model(NULL)
     fileImport(uploadedValues()[[1]][["data"]])
     data(uploadedValues()[[1]][["data"]])
+    log_object_size(data())
 
     # update notes in tab "Estimates" model download ----
     uploadedNotes(uploadedValues()[[1]][["notes"]])
@@ -872,6 +874,7 @@ modelResults2D <- function(input, output, session, isoData, savedMaps, fruitsDat
     }, min = 0, max = 1, value = 0.8, message = "Plotting map ...")
 
     values$predictions <- res$XPred
+    log_object_size(values$predictions)
     values$plot <- recordPlot()
   })
 

--- a/R/03-modelResults2DKernel.R
+++ b/R/03-modelResults2DKernel.R
@@ -895,6 +895,8 @@ modelResults2DKernel <- function(input, output, session, isoData, savedMaps, fru
         modelData$rNames <- rownames(modelData)
         modelData <- merge(modelData[, c("spatial_cluster", "long_centroid_spatial_cluster", "lat_centroid_spatial_cluster", "rNames")], allData, all.y = FALSE, sort = FALSE)
         modelData$rNames <- NULL
+        log_object_size(modelData)
+        log_memory_usage()
         return(modelData)
       } else {
         allData <- data()
@@ -903,6 +905,8 @@ modelResults2DKernel <- function(input, output, session, isoData, savedMaps, fru
         modelData$rNames <- rownames(modelData)
         modelData <- merge(modelData[, c("rNames"), drop = FALSE], allData, all.y = FALSE, sort = FALSE)
         modelData$rNames <- NULL
+        log_object_size(modelData)
+        log_memory_usage()
         return(modelData)
       }
     }

--- a/R/03-modelResults2DKernel.R
+++ b/R/03-modelResults2DKernel.R
@@ -397,6 +397,7 @@ modelResults2DKernel <- function(input, output, session, isoData, savedMaps, fru
     # reset model
     Model(NULL)
     data(activeData)
+    log_object_size(data())
   })
 
   coordType <- reactive({
@@ -446,6 +447,7 @@ modelResults2DKernel <- function(input, output, session, isoData, savedMaps, fru
     Model(NULL)
     fileImport(uploadedValues()[[1]][["data"]])
     data(uploadedValues()[[1]][["data"]])
+    log_object_size(data())
 
     # update notes in tab "Estimates" model download ----
     uploadedNotes(uploadedValues()[[1]][["notes"]])
@@ -817,6 +819,7 @@ modelResults2DKernel <- function(input, output, session, isoData, savedMaps, fru
       res <- plotFun()(Model())
     }, min = 0, max = 1, value = 0.8, message = "Plotting map ...")
     values$predictions <- res$XPred
+    log_object_size(values$predictions)
     values$plot <- recordPlot()
   })
 

--- a/R/03-modelResults2DKernel.R
+++ b/R/03-modelResults2DKernel.R
@@ -821,6 +821,7 @@ modelResults2DKernel <- function(input, output, session, isoData, savedMaps, fru
     values$predictions <- res$XPred
     log_object_size(values$predictions)
     values$plot <- recordPlot()
+    log_object_size(values$plot)
   })
 
   values <- reactiveValues(

--- a/R/03-modelResults2DKernel.R
+++ b/R/03-modelResults2DKernel.R
@@ -472,6 +472,7 @@ modelResults2DKernel <- function(input, output, session, isoData, savedMaps, fru
     req(length(uploadedValues()) > 0, !is.null(uploadedValues()[[1]][["model"]]))
     ## update model ----
     Model(unpackModel(uploadedValues()[[1]][["model"]]))
+    log_object_size(Model())
 
     uploadedSavedMaps <- unpackSavedMaps(uploadedValues()[[1]][["model"]], currentSavedMaps = savedMaps())
     savedMaps(c(savedMaps(), uploadedSavedMaps))
@@ -484,6 +485,7 @@ modelResults2DKernel <- function(input, output, session, isoData, savedMaps, fru
       if (length(savedMaps()) == 0) return(NULL)
 
       Model(savedMaps()[[as.numeric(input$savedModel)]]$model)
+      log_object_size(Model())
       return()
     }
     if (input$Latitude == "" | input$Longitude == "") {
@@ -521,6 +523,7 @@ modelResults2DKernel <- function(input, output, session, isoData, savedMaps, fru
       message = "Generating local kernel density model"
     )
     Model(model)
+    log_object_size(Model())
     updateSelectInput(session, "Centering", selected = input$centerOfData)
   })
 

--- a/R/03-modelResults3D.R
+++ b/R/03-modelResults3D.R
@@ -626,7 +626,6 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
     params <- reactiveValuesToList(input)
     params$coordType <- coordType()
 
-    log_memory_usage()
     model <- estimateMap3DWrapper(data(), params) %>%
       shinyTryCatch()
 

--- a/R/03-modelResults3D.R
+++ b/R/03-modelResults3D.R
@@ -1145,6 +1145,7 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
       allData$Outlier[which(rownames(allData) %in% outlier)] <- "model outlier"
       allData$Outlier[which(rownames(allData) %in% outlierDR)] <- "data outlier"
       log_object_size(allData)
+      log_memory_usage()
       return(allData)
     }
   })

--- a/R/03-modelResults3D.R
+++ b/R/03-modelResults3D.R
@@ -513,7 +513,6 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
     Model(NULL)
     data(activeData)
     log_object_size(data())
-    log_memory_usage()
   })
 
   coordType <- reactive({
@@ -569,7 +568,6 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
     fileImport(uploadedValues()[[1]][["data"]])
     data(uploadedValues()[[1]][["data"]])
     log_object_size(data())
-    log_memory_usage()
 
     # update notes in tab "Estimates" model download ----
     uploadedNotes(uploadedValues()[[1]][["notes"]])
@@ -599,7 +597,6 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
     ## update model ----
     Model(unpackModel(uploadedValues()[[1]][["model"]]))
     log_object_size(Model())
-    log_memory_usage()
 
     uploadedSavedMaps <- unpackSavedMaps(uploadedValues()[[1]][["model"]], currentSavedMaps = savedMaps())
     savedMaps(c(savedMaps(), uploadedSavedMaps))
@@ -614,7 +611,6 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
 
       Model(savedMaps()[[as.numeric(input$savedModel)]]$model)
       log_object_size(Model())
-      log_memory_usage()
       return()
     }
     values$set <- 0
@@ -636,7 +632,6 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
 
     Model(model)
     log_object_size(Model())
-    log_memory_usage()
     updateSelectInput(session, "Centering", selected = input$centerOfData)
   })
 
@@ -1044,7 +1039,6 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
     log_object_size(values$predictions)
     values$plot <- recordPlot()
     log_object_size(values$plot)
-    log_memory_usage()
   })
 
   values <- reactiveValues(plot = NULL, predictions = NULL,
@@ -1152,7 +1146,6 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
       allData$Outlier[which(rownames(allData) %in% outlier)] <- "model outlier"
       allData$Outlier[which(rownames(allData) %in% outlierDR)] <- "data outlier"
       log_object_size(allData)
-      log_memory_usage()
       return(allData)
     }
   })
@@ -1299,6 +1292,5 @@ modelResults3D <- function(input, output, session, isoData, savedMaps, fruitsDat
   observeEvent(batchModel(), {
     Model(batchModel())
     log_object_size(Model())
-    log_memory_usage()
   })
 }

--- a/R/03-modelResults3DKernel.R
+++ b/R/03-modelResults3DKernel.R
@@ -577,6 +577,7 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
     req(length(uploadedValues()) > 0, !is.null(uploadedValues()[[1]][["model"]]))
     ## update model ----
     Model(unpackModel(uploadedValues()[[1]][["model"]]))
+    log_object_size(Model())
 
     uploadedSavedMaps <- unpackSavedMaps(uploadedValues()[[1]][["model"]], currentSavedMaps = savedMaps())
     savedMaps(c(savedMaps(), uploadedSavedMaps))
@@ -589,6 +590,7 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
       if (length(savedMaps()) == 0) return(NULL)
 
       Model(savedMaps()[[as.numeric(input$savedModel)]]$model)
+      log_object_size(Model())
       return()
     }
 
@@ -634,6 +636,7 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
         message = "Generating spatio-temporal kernel density"
       )
       Model(model)
+      log_object_size(Model())
       updateSelectInput(session, "Centering", selected = input$centerOfData)
   })
 

--- a/R/03-modelResults3DKernel.R
+++ b/R/03-modelResults3DKernel.R
@@ -670,6 +670,7 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
   })
 
   zSettings <- zScaleServer("zScale",
+                            mapType = reactive(input$mapType),
                             Model = Model,
                             fixCol = reactive(input$fixCol),
                             estimationTypeChoices =

--- a/R/03-modelResults3DKernel.R
+++ b/R/03-modelResults3DKernel.R
@@ -1102,6 +1102,7 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
     values$predictions <- res$XPred
     log_object_size(values$predictions)
     values$plot <- recordPlot()
+    log_object_size(values$plot)
   })
 
   values <- reactiveValues(plot = NULL, predictions = NULL,

--- a/R/03-modelResults3DKernel.R
+++ b/R/03-modelResults3DKernel.R
@@ -507,6 +507,7 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
     # reset model
     Model(NULL)
     data(activeData)
+    log_object_size(data())
   })
 
   coordType <- reactive({
@@ -551,6 +552,7 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
     Model(NULL)
     fileImport(uploadedValues()[[1]][["data"]])
     data(uploadedValues()[[1]][["data"]])
+    log_object_size(data())
 
     # update notes in tab "Estimates" model download ----
     uploadedNotes(uploadedValues()[[1]][["notes"]])
@@ -1098,6 +1100,7 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
       res <- plotFun()(Model())
     }, min = 0, max = 1, value = 0.8, message = "Plotting map ...")
     values$predictions <- res$XPred
+    log_object_size(values$predictions)
     values$plot <- recordPlot()
   })
 

--- a/R/03-modelResults3DKernel.R
+++ b/R/03-modelResults3DKernel.R
@@ -400,7 +400,6 @@ modelResults3DKernelUI <- function(id, title = ""){
             sliderInput(inputId = ns("ncol"),
                         label = "Approximate number of colour levels",
                         min = 4, max = 50, value = 50, step = 2, width = "100%"),
-            centerEstimateUI(ns("centerEstimateParams")),
             tags$hr()
             ),
           checkboxInput(inputId = ns("smoothCols"),
@@ -442,7 +441,7 @@ modelResults3DKernelUI <- function(id, title = ""){
           sliderInput(inputId = ns("AxisLSize"),
                       label = "Axis label font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
-
+          centerEstimateUI(ns("centerEstimateParams")),
           batchPointEstimatesUI(ns("batch"))
         )
     )

--- a/R/03-modelResults3DKernel.R
+++ b/R/03-modelResults3DKernel.R
@@ -1182,6 +1182,8 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
         modelData$rNames <- NULL
         # filter data that was filtered out for clustering
         modelData <- modelData[!is.na(modelData$long_centroid_spatial_cluster),]
+        log_object_size(modelData)
+        log_memory_usage()
         return(modelData)
       } else {
         allData <- data()
@@ -1190,6 +1192,8 @@ modelResults3DKernel <- function(input, output, session, isoData, savedMaps, fru
         modelData$rNames <- rownames(modelData)
         modelData <- merge(modelData[, c("rNames"), drop = FALSE], allData, all.y = FALSE, sort = FALSE)
         modelData$rNames <- NULL
+        log_object_size(modelData)
+        log_memory_usage()
         return(modelData)
       }
     }

--- a/R/03-modelResultsAssign.R
+++ b/R/03-modelResultsAssign.R
@@ -583,6 +583,8 @@ modelResultsAssign <- function(input, output, session, isoData) {
       if (input$showData & input$aggType == "single") {
         estimate <- cbind(estimate, data)
       }
+      log_object_size(estimate)
+      log_memory_usage()
       return(estimate)
     }
   })

--- a/R/03-modelResultsAssign.R
+++ b/R/03-modelResultsAssign.R
@@ -279,6 +279,7 @@ modelResultsAssign <- function(input, output, session, isoData) {
     req(length(uploadedValues()) > 0, !is.null(uploadedValues()[[1]][["model"]]))
     ## update model ----
     Model(uploadedValues()[[1]][["model"]])
+    log_object_size(Model())
   }) %>%
     bindEvent(uploadedValues())
 
@@ -395,6 +396,7 @@ modelResultsAssign <- function(input, output, session, isoData) {
        shinyTryCatch()
 
       Model(list(models = models, predictions = predictions, data = dataAssignR, X = X))
+      log_object_size(Model())
     }
   })
 

--- a/R/03-modelResultsAssign.R
+++ b/R/03-modelResultsAssign.R
@@ -223,6 +223,7 @@ modelResultsAssign <- function(input, output, session, isoData) {
     # reset model
     Model(NULL)
     data(activeData)
+    log_object_size(data())
   })
 
   # MODEL DOWN- / UPLOAD ----
@@ -255,6 +256,7 @@ modelResultsAssign <- function(input, output, session, isoData) {
     Model(NULL)
     fileImport(uploadedValues()[[1]][["data"]])
     data(uploadedValues()[[1]][["data"]])
+    log_object_size(data())
 
     # update notes in tab "Estimates" model download ----
     uploadedNotes(uploadedValues()[[1]][["notes"]])

--- a/R/03-modelResultsSpread.R
+++ b/R/03-modelResultsSpread.R
@@ -470,6 +470,7 @@ modelResultsSpread <- function(input, output, session, isoData, savedMaps, fruit
     # reset model
     Model(NULL)
     data(activeData)
+    log_object_size(data())
   })
 
   coordType <- reactive({
@@ -517,6 +518,7 @@ modelResultsSpread <- function(input, output, session, isoData, savedMaps, fruit
     Model(NULL)
     fileImport(uploadedValues()[[1]][["data"]])
     data(uploadedValues()[[1]][["data"]])
+    log_object_size(data())
 
     # update notes in tab "Estimates" model download ----
     uploadedNotes(uploadedValues()[[1]][["notes"]])
@@ -910,6 +912,7 @@ modelResultsSpread <- function(input, output, session, isoData, savedMaps, fruit
       alert(res)
     } else{
       values$predictions <- res$XPred
+      log_object_size(values$predictions)
       values$plot <- recordPlot()
     }
   })
@@ -986,6 +989,7 @@ modelResultsSpread <- function(input, output, session, isoData, savedMaps, fruit
       allData$Outlier <- "non-outlier"
       allData$Outlier[which(rownames(allData) %in% outlier)] <- "model outlier"
       allData$Outlier[which(rownames(allData) %in% outlierDR)] <- "data outlier"
+      log_object_size(allData)
       return(allData)
     }
   })

--- a/R/03-modelResultsSpread.R
+++ b/R/03-modelResultsSpread.R
@@ -991,6 +991,7 @@ modelResultsSpread <- function(input, output, session, isoData, savedMaps, fruit
       allData$Outlier[which(rownames(allData) %in% outlier)] <- "model outlier"
       allData$Outlier[which(rownames(allData) %in% outlierDR)] <- "data outlier"
       log_object_size(allData)
+      log_memory_usage()
       return(allData)
     }
   })

--- a/R/03-modelResultsSpread.R
+++ b/R/03-modelResultsSpread.R
@@ -543,6 +543,7 @@ modelResultsSpread <- function(input, output, session, isoData, savedMaps, fruit
     req(length(uploadedValues()) > 0, !is.null(uploadedValues()[[1]][["model"]]))
     ## update model ----
     Model(unpackModel(uploadedValues()[[1]][["model"]]))
+    log_object_size(Model())
 
     uploadedSavedMaps <- unpackSavedMaps(uploadedValues()[[1]][["model"]], currentSavedMaps = savedMaps())
     savedMaps(c(savedMaps(), uploadedSavedMaps))
@@ -555,6 +556,7 @@ modelResultsSpread <- function(input, output, session, isoData, savedMaps, fruit
       if (length(savedMaps()) == 0) return(NULL)
 
       Model(savedMaps()[[as.numeric(input$savedModel)]]$model)
+      log_object_size(Model())
       return()
     }
 
@@ -573,6 +575,7 @@ modelResultsSpread <- function(input, output, session, isoData, savedMaps, fruit
       shinyTryCatch()
 
     Model(model)
+    log_object_size(Model())
     updateSelectInput(session, "Centering", selected = input$centerOfData)
   })
 

--- a/R/03-modelResultsSpread.R
+++ b/R/03-modelResultsSpread.R
@@ -914,6 +914,7 @@ modelResultsSpread <- function(input, output, session, isoData, savedMaps, fruit
       values$predictions <- res$XPred
       log_object_size(values$predictions)
       values$plot <- recordPlot()
+      log_object_size(values$plot)
     }
   })
 


### PR DESCRIPTION
# DSSM 26.01.0

## Updates
- Added logging of object sizes also to the modelling tabs _KernelR, KernelTimeR, SpreadR AssignR_ (#206)

## Bug Fixes
- Fixed hidden UI for setting the center estimates in _KernelTimeR_ time course plots (#292)
- Fixed decimal-place settings for axis labels: x and y axes now have separate inputs, with an improved default for the y axis (1 decimal place) to prevent rounding issues (#292)