### PR TITLE
Release DSSM 26.04.1: changes from Beta

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,17 +2,12 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Shiny App",
-            "type": "R-Debugger",
-            "request": "launch",
-            "file": "${workspaceFolder}/inst/main.R",
-            "env": {}
-        },
-        {
             "name": "Debug Active R Script",
             "type": "R-Debugger",
             "request": "launch",
-            "env": {}
+            "env": {
+                "R_PROFILE_USER": "${workspaceFolder}/.Rprofile"
+            }
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "r.alwaysUseActiveTerminal": false,
+  "terminal.integrated.cwd": "${workspaceFolder}"
+}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: DSSM
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 26.04.0
+Version: 26.04.1
+Date: 2026-04-30
 Authors@R: c(
             person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("cre", "aut")),
             person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DSSM
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 26.03.2
+Version: 26.04.0
 Authors@R: c(
             person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("cre", "aut")),
             person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -593,3 +593,20 @@ more useful to permit linking proprietary applications with the library. If this
 what you want to do, use the GNU Lesser General Public License instead of this
 License. But first, please read
 &lt;<http://www.gnu.org/philosophy/why-not-lgpl.html>&gt;.
+
+---
+
+## Third-Party Licenses
+
+### rnaturalearth
+This project uses the rnaturalearth R package, which is distributed under the MIT License.
+
+**Copyright (c) 2017 Andy South and contributors**
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+**Source:** https://github.com/ropensci/rnaturalearth

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# DSSM 26.04.0
+
+## Updates
+- Added rnaturalearth attribution in `RScripts/update_maps.R`, and added an acknowledgments section in `README.md`.
+- Appended a “Third-Party Licenses” section (including MIT license text for rnaturalearth) to `LICENSE.md`.
+- Added a recommended citation for mclust in `README.md`.
+
 # DSSM 26.03.2
 
 ## Updates

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DSSM 26.04.1
+
+## Updates
+- _Interactive map export_: added a notice about third-party basemap licenses/terms and attribution requirements, and added a corresponding note to `README.md`.
+
 # DSSM 26.04.0
 
 ## Updates

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DSSM 26.03.2
+
+## Updates
+- Refactored the summarise() call in findDuplicates() to remove the deprecated unnamed column expression, fixing compatibility with recent dplyr versions.
+
 # DSSM 26.03.1
 
 ## Updates

--- a/R/01-estimateMap.R
+++ b/R/01-estimateMap.R
@@ -1677,7 +1677,7 @@ modelLocalTempAvg <- function(data, K, KT, iter, burnin, independent,
     showMessage(
       MCMC_LocalTempAvg,
       msg = msg,
-      detail = paste0("Chain ", nChains),
+      detail = paste0("Chain ", nChains, ", Chunk ", k, "/10"),
       value = k / 10)(
         start = j, iter = j + iter / 10 - 1
       )

--- a/R/02-leafletExport.R
+++ b/R/02-leafletExport.R
@@ -49,7 +49,24 @@ leafletExport <- function(input,
     showModal(
       modalDialog(
         title = "Export Map",
-        footer = modalButton("OK"),
+        footer = tagList(
+          tags$div(
+            style = "float: left; max-width: calc(100% - 70px); text-align: left;",
+            helpText(
+              tagList(
+                "Note: Basemaps in the 'Interactive map' tab are provided by third parties and subject to their own licenses/terms. Users are responsible for ensuring permitted reuse/publication (",
+                tags$a(
+                  href = "https://leaflet-extras.github.io/leaflet-providers/preview/",
+                  target = "_blank",
+                  rel = "noopener noreferrer",
+                  "Leaflet providers"
+                ),
+                "). Please verify that required basemap attribution is visible in the exported figure before publication."
+              )
+            )
+          ),
+          modalButton("OK")
+        ),
         fluidRow(
           column(4, numericInput(ns("width"), "Width (px)", value = width())),
           column(4, numericInput(ns("height"), "Height (px)", value = height())),

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This project is licensed under the GNU General Public License v3. It incorporate
 
 - **rnaturalearth** (MIT License) - Provides map data from Natural Earth. See [LICENSE.md](LICENSE.md) for full license details.
 
+Interactive basemaps shown via Leaflet providers are provided by third parties and remain subject to their own licenses, attribution requirements, and terms of use. Users are responsible for ensuring permitted reuse and publication of any exported or published maps. A reference list of supported Leaflet providers is available at [leaflet-providers preview](https://leaflet-extras.github.io/leaflet-providers/preview/).
+
 ## Recommended Citations
 
 If you reference methods implemented through this application in academic work, please also cite mclust as recommended by its authors:

--- a/README.md
+++ b/README.md
@@ -65,3 +65,17 @@ and access the app in your browser at `http://localhost:3838/`. Stop the contain
 **Optional:**
 
 Add `-it` for interactive mode, or `--rm` to remove the container after stopping.
+
+## Acknowledgments
+
+This project is licensed under the GNU General Public License v3. It incorporates third-party packages with their respective licenses:
+
+- **rnaturalearth** (MIT License) - Provides map data from Natural Earth. See [LICENSE.md](LICENSE.md) for full license details.
+
+## Recommended Citations
+
+If you reference methods implemented through this application in academic work, please also cite mclust as recommended by its authors:
+
+Scrucca L, Fraley C, Murphy TB, Raftery AE (2023). _Model-Based Clustering, Classification, and Density Estimation Using mclust in R_. Chapman and Hall/CRC. ISBN 978-1032234953, doi:10.1201/9781003277965, <https://mclust-org.github.io/book/>.
+
+For complete license information, please see [LICENSE.md](LICENSE.md).

--- a/RScripts/update_maps.R
+++ b/RScripts/update_maps.R
@@ -1,6 +1,11 @@
 library(rnaturalearth)
 library(sf) # load whole library to enable syntax for overwriting of st_geometry and st_crs
 
+# This script uses the rnaturalearth package (MIT License)
+# rnaturalearth (c) 2017 Andy South and contributors
+# https://github.com/ropensci/rnaturalearth
+# See LICENSE.md for full license details
+
 # Update maps of package
 #
 # This function downloads maps from the package 'rnaturalearth' and saves them into the folder for


### PR DESCRIPTION
# DSSM 26.04.1

## Updates
- _Interactive map export_: added a notice about third-party basemap licenses/terms and attribution requirements, and added a corresponding note to `README.md`.

# DSSM 26.04.0

## Updates
- Added rnaturalearth attribution in `RScripts/update_maps.R`, and added an acknowledgments section in `README.md`.
- Appended a “Third-Party Licenses” section (including MIT license text for rnaturalearth) to `LICENSE.md`.
- Added a recommended citation for mclust in `README.md`.

# DSSM 26.03.2

## Updates
- Refactored the summarise() call in findDuplicates() to remove the deprecated unnamed column expression, fixing compatibility with recent dplyr versions.