### PR TITLE
# DSSM 26.04.1: note for third party providers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: DSSM
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 26.04.0
+Version: 26.04.1
+Date: 2026-04-30
 Authors@R: c(
             person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("cre", "aut")),
             person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DSSM 26.04.1
+
+## Updates
+- _Interactive map export_: added a notice about third-party basemap licenses/terms and attribution requirements, and added a corresponding note to `README.md`.
+
 # DSSM 26.04.0
 
 ## Updates

--- a/R/02-leafletExport.R
+++ b/R/02-leafletExport.R
@@ -49,7 +49,24 @@ leafletExport <- function(input,
     showModal(
       modalDialog(
         title = "Export Map",
-        footer = modalButton("OK"),
+        footer = tagList(
+          tags$div(
+            style = "float: left; max-width: calc(100% - 70px); text-align: left;",
+            helpText(
+              tagList(
+                "Note: Basemaps in the 'Interactive map' tab are provided by third parties and subject to their own licenses/terms. Users are responsible for ensuring permitted reuse/publication (",
+                tags$a(
+                  href = "https://leaflet-extras.github.io/leaflet-providers/preview/",
+                  target = "_blank",
+                  rel = "noopener noreferrer",
+                  "Leaflet providers"
+                ),
+                "). Please verify that required basemap attribution is visible in the exported figure before publication."
+              )
+            )
+          ),
+          modalButton("OK")
+        ),
         fluidRow(
           column(4, numericInput(ns("width"), "Width (px)", value = width())),
           column(4, numericInput(ns("height"), "Height (px)", value = height())),

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ This project is licensed under the GNU General Public License v3. It incorporate
 
 - **rnaturalearth** (MIT License) - Provides map data from Natural Earth. See [LICENSE.md](LICENSE.md) for full license details.
 
+Interactive basemaps shown via Leaflet providers are provided by third parties and remain subject to their own licenses, attribution requirements, and terms of use. Users are responsible for ensuring permitted reuse and publication of any exported or published maps. A reference list of supported Leaflet providers is available at [leaflet-providers preview](https://leaflet-extras.github.io/leaflet-providers/preview/).
+
 ## Recommended Citations
 
 If you reference methods implemented through this application in academic work, please also cite mclust as recommended by its authors:


### PR DESCRIPTION
# DSSM 26.04.1

## Updates
- _Interactive map export_: added a notice about third-party basemap licenses/terms and attribution requirements, and added a corresponding note to `README.md`.